### PR TITLE
Decode image before calculating sample size.

### DIFF
--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/utils/BitmapUtils.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/utils/BitmapUtils.java
@@ -342,9 +342,15 @@ public class BitmapUtils {
     }
 
     public static Bitmap getSampledBitmap(String filePath, int reqWidth, int reqHeight) {
+        // First decode with inJustDecodeBounds=true to check dimensions
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
+        BitmapFactory.decodeFile(filePath, options);
+
+        // Calculate inSampleSize
         options.inSampleSize = calculateInSampleSize(options, reqWidth, reqHeight);
+
+        // Decode bitmap with inSampleSize set
         options.inPreferredConfig = Bitmap.Config.RGB_565;
         options.inJustDecodeBounds = false;
         return imageOrientationValidator(BitmapFactory.decodeFile(filePath, options), filePath);


### PR DESCRIPTION
When trying to edit a large image, the app crashes due to
`Fatal Exception: java.lang.RuntimeException: Canvas: trying to draw too large(127401984bytes) bitmap.
       at android.graphics.RecordingCanvas.throwIfCannotDraw(RecordingCanvas.java:282)
       at android.graphics.BaseRecordingCanvas.drawBitmap(BaseRecordingCanvas.java:69)
       at iamutkarshtiwari.github.io.ananas.editimage.view.imagezoom.graphic.FastBitmapDrawable.draw(FastBitmapDrawable.java:37)`.

Following official documentation: [https://developer.android.com/topic/performance/graphics/load-bitmap.html#java](url), in function `getSampledBitmap` of class `BitmapUtils` the original authors missed one line of code to avoid this issue (the sampleSize is the factor of how much you need to compress the image to fit given dimensions, but to calculate it you need to decode the image once before to learn the original dimensions. If not, sampleSize will always stay at 1 meaning the image doesn't get smaller)

This issue was highlighted in original repo but was never implemented: [https://github.com/iamutkarshtiwari/Ananas/issues/105](url)

PR for BS-3727.