### PR TITLE
Update to Android 13

### DIFF
--- a/ananas/build.gradle
+++ b/ananas/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'kotlin-kapt'
 
 group='com.github.nsocheleau'
@@ -21,8 +20,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     packagingOptions{
         doNotStrip '*/mips/*.so'
@@ -34,7 +33,7 @@ dependencies {
     testImplementation "junit:junit:${junit_version}"
     testImplementation "org.robolectric:robolectric:${robolectric_version}"
     implementation "androidx.appcompat:appcompat:${androidx_compat}"
-    implementation "androidx.recyclerview:recyclerview:${androidx_version}"
+    implementation "androidx.recyclerview:recyclerview:1.3.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
     implementation "com.github.eltos:simpledialogfragment:${simple_dialog_fragment_version}"
     api "com.theartofdev.edmodo:android-image-cropper:${cropper_version}"

--- a/ananas/src/main/AndroidManifest.xml
+++ b/ananas/src/main/AndroidManifest.xml
@@ -7,8 +7,6 @@
             android:name="iamutkarshtiwari.github.io.ananas.editimage.EditImageActivity"
             android:label="@string/iamutkarshtiwari_github_io_ananas_library_name"
             android:exported="true" />
-
-        <activity android:name="iamutkarshtiwari.github.io.imageeditorsample.picchooser.SelectPictureActivity" />
     </application>
 
 </manifest>

--- a/ananas/src/main/AndroidManifest.xml
+++ b/ananas/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="iamutkarshtiwari.github.io.ananas">
 
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <application>
         <activity
             android:name="iamutkarshtiwari.github.io.ananas.editimage.EditImageActivity"

--- a/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
+++ b/ananas/src/main/java/iamutkarshtiwari/github/io/ananas/editimage/EditImageActivity.java
@@ -77,7 +77,7 @@ public class EditImageActivity extends BaseActivity implements OnLoadingDialogLi
     public static final int MODE_SATURATION = 9;
     private static final int PERMISSIONS_REQUEST_CODE = 110;
     private final String[] requiredPermissions = new String[]{
-            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ? Manifest.permission.READ_EXTERNAL_STORAGE : Manifest.permission.READ_MEDIA_IMAGES,
             Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.github.dcendents.android-maven'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
@@ -18,8 +17,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
@@ -27,7 +26,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "androidx.appcompat:appcompat:${androidx_version}"
     androidTestImplementation "junit:junit:${junit_version}"
-    androidTestImplementation "androidx.test:runner:$androidx_version"
+    androidTestImplementation "androidx.test:runner:1.5.2"
     androidTestImplementation "androidx.test.espresso:espresso-core:${espresso_version}"
     implementation project(':ananas')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${gradle_version}"
-        classpath "com.github.dcendents:android-maven-gradle-plugin:${maven_plugin_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -31,9 +30,9 @@ allprojects {
 
     project.ext {
         buildToolsVersion="20.0.0"
-        minSdkVersion=16
-        targetSdkVersion=27
-        compileSdkVersion=28
+        minSdkVersion=21
+        targetSdkVersion=33
+        compileSdkVersion=33
     }
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
@@ -21,8 +20,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <uses-feature android:name="android.hardware.camera"
         android:required="true" />
 

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:label="@string/ananas_image_editor_app_name">
         <activity
             android:name="iamutkarshtiwari.github.io.imageeditorsample.MainActivity"
-            android:label="@string/ananas_image_editor_app_name">
+            android:label="@string/ananas_image_editor_app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/demo/src/main/java/iamutkarshtiwari/github/io/imageeditorsample/MainActivity.java
+++ b/demo/src/main/java/iamutkarshtiwari/github/io/imageeditorsample/MainActivity.java
@@ -151,14 +151,18 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     private void openAlbumWithPermissionsCheck() {
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
+        if (ActivityCompat.checkSelfPermission(this, getMediaPermission())
                 != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(this,
-                    new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                    new String[]{getMediaPermission()},
                     REQUEST_PERMISSION_STORAGE);
             return;
         }
         openAlbum();
+    }
+
+    private String getMediaPermission() {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ? Manifest.permission.READ_EXTERNAL_STORAGE : Manifest.permission.READ_MEDIA_IMAGES;
     }
 
     private void handleEditorImage(Intent data) {

--- a/demo/src/main/java/iamutkarshtiwari/github/io/imageeditorsample/imagepicker/activity/ImagePickerActivity.kt
+++ b/demo/src/main/java/iamutkarshtiwari/github/io/imageeditorsample/imagepicker/activity/ImagePickerActivity.kt
@@ -60,6 +60,7 @@ class ImagePickerActivity : ParentActivity(R.layout.activity_main) {
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
@@ -103,7 +104,7 @@ class ImagePickerActivity : ParentActivity(R.layout.activity_main) {
     }
 
     private fun chooseImage() {
-        startActivityForResult(getPickImageIntent(), RES_IMAGE)
+        startActivityForResult(getPickImageIntent()!!, RES_IMAGE)
     }
 
     private fun getPickImageIntent(): Intent? {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 
-androidx_version=1.2.1
+androidx_version=1.6.1
 androidx_core_version=1.0.1
 androidx_compat=1.3.0
 androidx_multidex=2.0.1
@@ -36,10 +36,12 @@ mockito_version=2.16.0
 rxjava_version=2.2.21
 rxandroid_version=2.1.1
 glide_version=4.12.0
-kotlin_version=1.5.10
+kotlin_version=1.6.20
 
-gradle_version=4.0.1
+gradle_version=7.4.1
 maven_plugin_version=2.1
 core_ktx_version=1.6.0-rc01
 constraint_layout_version=1.1.3
 coroutine_version=1.4.3
+
+android.disableAutomaticComponentCreation=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update project to target Android 13 (updated some dependencies, the kotlin version, the gradle version and the java version. Ran the Ananas app in latest Android Studio)
Removed `apply plugin: 'com.github.dcendents.android-maven'` because it was required for the gradle update

Use the correct permission `READ_MEDIA_IMAGES` for Android 13 to fix current issue in Bolt where users are unable to edit images if they have Android 13+ (BS-5004)